### PR TITLE
config sync unreliable: exchange file watcher for JVL's implementation

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,37 +7,13 @@ assignees: ''
 
 ---
 
-Thanks for taking the time to report a bug. Please fill in the template below and delete any irrelevant parts.
+Thanks for taking the time to report a bug. Please don't forget to include your **log file** and **config file** so that I can assist you properly.
 
-# Description
+### Where are my files?
 
-A description of what the bug is. eg. My skeleton keeps blowing up when I press E on him.
-
-## Attachments Checklist
-
-Drag and drop the files onto the page:
-
-- [ ] Log file (Steam/steamapps/common/Valheim/BepInEx/LogOutput.log):
-- [ ] Config file (Steam/steamapps/common/Valheim/BepInEx/config/com.chebgonaz...):
-
-GitHub annoyingly rejects the .cfg file extension. You can zip it and upload that, or open the file and then copy & paste all contents just below:
-
-<details><summary>Config text dump</summary>
-CONFIG FILE TEXT HERE
-</details>
-
-## To Reproduce (if applicable)
-
-Steps to reproduce the bug. For example:
-1. Interact with skeleton using E
-2. Skeleton blows up
-3. See error
-
-## Expected behaviour (if applicable)
-
-A description of what you expected to happen. eg. Skeleton should not blow up.
-
-## Screenshots (if applicable)
-
-If applicable, add screenshots to help explain your problem.
-
+File | Method | Location
+--- | --- | ---
+Log | Manual install | `Steam/steamapps/common/Valheim/BepInEx/LogOutput.log`
+Log | R2modmanager | Settings->Debugging->Copy log file contents to clipboard
+Config | Manual install | `Steam/steamapps/common/Valheim/BepInEx/config/com.chebgonaz...`
+Config | R2modmanager | Settings->Locations->Browser profile data

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -7,16 +7,4 @@ assignees: ''
 
 ---
 
-# Description
-
-A description of what you want.
-
-## Is the feature related to a problem?
-
-Yes. I'm always frustrated when ...
-
-## Solutions
-
-### Your Ideal Solution
-
-Ideally, there would be a X that works like Y and Z.
+Please describe your desired feature.

--- a/ChebsThrownWeapons/ChebsThrownWeapons.cs
+++ b/ChebsThrownWeapons/ChebsThrownWeapons.cs
@@ -78,13 +78,8 @@ namespace ChebsThrownWeapons
 
             PrefabManager.OnVanillaPrefabsAvailable += DoOnVanillaPrefabsAvailable;
         }
-
-        private void DoOnVanillaPrefabsAvailable()
-        {
-            UpdateAllRecipes();
-            PrefabManager.OnVanillaPrefabsAvailable -= DoOnVanillaPrefabsAvailable;
-        }
         
+        #region ConfigUpdate
         private byte[] GetFileHash(string fileName)
         {
             var sha1 = HashAlgorithm.Create();
@@ -106,7 +101,29 @@ namespace ChebsThrownWeapons
                 }
             }
         }
+        
+        private void ReadConfigValues()
+        {
+            try
+            {
+                var adminOrLocal = ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance();
+                Logger.LogInfo($"Read updated config values (admin/local={adminOrLocal})");
+                if (adminOrLocal) Config.Reload();
+                UpdateAllRecipes(true);
+            }
+            catch (Exception exc)
+            {
+                Logger.LogError($"There was an issue loading your {ConfigFileName}: {exc}");
+            }
+        }
+        #endregion
 
+        private void DoOnVanillaPrefabsAvailable()
+        {
+            UpdateAllRecipes();
+            PrefabManager.OnVanillaPrefabsAvailable -= DoOnVanillaPrefabsAvailable;
+        }
+        
         private void UpdateItemsInScene(List<ItemDrop> itemDropList)
         {
             if (ZNetScene.instance == null)
@@ -179,20 +196,7 @@ namespace ChebsThrownWeapons
             BlackMetalThrowingAxe.CreateConfigs(this);
         }
 
-        private void ReadConfigValues()
-        {
-            try
-            {
-                var adminOrLocal = ZNet.instance.IsServerInstance() || ZNet.instance.IsLocalInstance();
-                Logger.LogInfo($"Read updated config values (admin/local={adminOrLocal})");
-                if (adminOrLocal) Config.Reload();
-                UpdateAllRecipes(true);
-            }
-            catch (Exception exc)
-            {
-                Logger.LogError($"There was an issue loading your {ConfigFileName}: {exc}");
-            }
-        }
+        
 
         private void LoadAssetBundle()
         {

--- a/ChebsThrownWeapons/Package/README.md
+++ b/ChebsThrownWeapons/Package/README.md
@@ -109,6 +109,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-thrown-weapons).
 
  Date | Version | Notes 
 --- | --- | ---
+29/11/2023 | 1.3.3 | Fix issue of configs not syncing reliably
 28/11/2023 | 1.3.2 | fix bug where blocking using a weapon would crash the game
 01/11/2023 | 1.3.1 | fix bug of fire javelin's fire damage not being applied from config; fixed bug of javelins not being upgradable; add new configurations for tweaking durability, durability per level, and how much an item can be upgraded
 26/08/2023 | 1.2.1 | update CVL; revise dev scripts and assembly info

--- a/ChebsThrownWeapons/Package/manifest.json
+++ b/ChebsThrownWeapons/Package/manifest.json
@@ -1,7 +1,7 @@
 ﻿{
   "name": "ChebsThrownWeapons",
   "description": "Adds throwing weapons to Valheim: Javelins, Shuriken, Throwing Axes.",
-  "version_number": "1.3.2",
+  "version_number": "1.3.3",
   "website_url": "https://github.com/jpw1991/chebs-thrown-weapons",
   "dependencies": [
     "ValheimModding-Jotunn-2.11.2"

--- a/ChebsThrownWeapons/Properties/AssemblyInfo.cs
+++ b/ChebsThrownWeapons/Properties/AssemblyInfo.cs
@@ -31,5 +31,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.3.2.0")]
-[assembly: AssemblyFileVersion("1.3.2.0")]
+[assembly: AssemblyVersion("1.3.3.0")]
+[assembly: AssemblyFileVersion("1.3.3.0")]

--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ You can find the github [here](https://github.com/jpw1991/chebs-thrown-weapons).
 
  Date | Version | Notes 
 --- | --- | ---
+29/11/2023 | 1.3.3 | Fix issue of configs not syncing reliably
 28/11/2023 | 1.3.2 | fix bug where blocking using a weapon would crash the game
 01/11/2023 | 1.3.1 | fix bug of fire javelin's fire damage not being applied from config; fixed bug of javelins not being upgradable; add new configurations for tweaking durability, durability per level, and how much an item can be upgraded
 26/08/2023 | 1.2.1 | update CVL; revise dev scripts and assembly info

--- a/update_podman_mods.sh
+++ b/update_podman_mods.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+podman exec -d 00111176c93c /bin/bash -c 'rm -rf /config/bepinex/plugins'
+podman cp /home/$USER/.config/r2modmanPlus-local/Valheim/profiles/cheb-development/BepInEx/plugins 00111176c93c:/config/bepinex
+


### PR DESCRIPTION
## Description

Throw out the FileSystemWatcher and replace it with JVL's synchronization manager. Except, it seems to not work for me in this case... (probably my fault)

EDIT: Turns out that FileSystemWatcher is [unreliable inside containers](https://stackoverflow.com/questions/57024640/why-filesystemwatcher-doesnt-work-in-linux-container-watching-windows-volume), so I have replaced it with a hash comparison.

## ~~Problem~~ Fixed

~~The initial sync occurs, as is seen in the log, but the subsequent resync after the file is modified does not occur on the server nor the client.~~ fixed

![server_sync_debugging](https://github.com/jpw1991/chebs-thrown-weapons/assets/13718599/44463d0a-5e97-4cd8-94f3-94414166469e)

[LogOutput.log (Client)](https://github.com/jpw1991/chebs-thrown-weapons/files/13483361/LogOutput.log)
